### PR TITLE
Corrected issue in which the README for GUI installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,6 @@ After installing anaconda one can create virtual environment where to host the `
 ```
 conda create --name ASD_GUI_env python=3.6 vtk=8.1.0 numpy scipy matplotlib yaml pyyaml pandas
 conda activate ASD_GUI_env
-conda install -c conda-forge enum-compat
 conda install -c anaconda pyqt
 ```
 This will generate a virtual environment named `ASD_GUI_env` which can be activated or deactivated to run the GUI.

--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ After installing anaconda one can create virtual environment where to host the `
 
 ```
 conda create --name ASD_GUI_env python=3.6 vtk=8.1.0 numpy scipy matplotlib yaml pyyaml pandas
-source activate ASD_GUI_env
-conda install -c menpo enum 
-conda install -c qt5 pyqt5
+conda activate ASD_GUI_env
+conda install -c conda-forge enum-compat
+conda install -c anaconda pyqt
 ```
 This will generate a virtual environment named `ASD_GUI_env` which can be activated or deactivated to run the GUI.
 


### PR DESCRIPTION
The conda channel recommended for `enum` was for python2 which is no longer supported, the `README.md` has been updated to remove some of the confusion that this can cause. Closes #14 