### PR TITLE
Fix bug in montecarlo_common.f90:flip_h subroutine (heatbath)

### DIFF
--- a/source/MonteCarlo/montecarlo_common.f90
+++ b/source/MonteCarlo/montecarlo_common.f90
@@ -399,21 +399,10 @@ contains
       zfc=beta*totfield*mub*mmom
       zarg=sqrt(sum(zfc(:)*zfc(:)))
       zctheta=zfc(3)/zarg
-      zstheta=sqrt(1.0_dblprec-zctheta*zctheta)
-      !if (zstheta < 1.d-2) then
-      if (zstheta < 1.d-6) then
-         !zctheta=0.999950_dblprec
-         !zctheta=0.999999995_dblprec
-         zctheta=0.9999999999995_dblprec
-         zstheta=1.d-6
-         !zcphi=1.0_dblprec
-         !zsphi=0.0_dblprec
-         zcphi=zfc(1)/(zarg*zstheta)
-         zsphi=zfc(2)/(zarg*zstheta)
-      else
-         zcphi=zfc(1)/(zarg*zstheta)
-         zsphi=zfc(2)/(zarg*zstheta)
-      endif
+      ! add tolerance so zstheta is never zero - that could result in NaNs because we divide by it later
+      zstheta=sqrt(1.0_dblprec-zctheta*zctheta)+dbl_tolerance
+      zcphi=zfc(1)/(zarg*zstheta)
+      zsphi=zfc(2)/(zarg*zstheta)
       !ctheta=1.50_dblprec
       !do while (abs(ctheta)>1.0_dblprec)
       !   call rng_uniform(q,1)


### PR DESCRIPTION
Fix a bug in calculating the polar coordinates of a spin in the flip_h subroutine, used in heatbath calculations.

This bug caused spins which were close to the -1 z-pole to incorrectly flip to +1 z-pole.
This happened in the if clause where zstheta < 1.d-2. The if clause incorrectly assumed that zctheta is close to +1 in that case, while it can also be close to -1.

I am attaching a PDF analyzing the faulty behaviour in more detail:
[UppASD_hb_comparison.pdf](https://github.com/UppASD/UppASD/files/11734005/UppASD_hb_comparison.pdf)
