### PR TITLE
Mac action

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -16,20 +16,6 @@ jobs:
         #os: [ubuntu-20.04, ubuntu-latest,  macOS-11, macOS-latest]
 
     steps:
-      - name: Provide gfortran (macOS)
-        if: runner.os == 'macOS'
-        run: |
-          # https://github.com/actions/virtual-environments/issues/2524
-          # https://github.com/cbg-ethz/dce/blob/master/.github/workflows/pkgdown.yaml
-          sudo ln -s /usr/local/bin/gfortran-12 /usr/local/bin/gfortran
-          sudo ln -s /usr/local/bin/gcc-12 /usr/local/bin/gcc
-          sudo mkdir /usr/local/gfortran
-          sudo ln -s /usr/local/Cellar/gcc@12/*/lib/gcc/12 /usr/local/gfortran/lib
-          gfortran --version
-          gcc --version
-          which gcc
-          which gfortran
-
       - name: Provide fftw  (macOS)
         if: runner.os == 'macOS'
         run: |

--- a/.github/workflows/linuxbuilds.yml
+++ b/.github/workflows/linuxbuilds.yml
@@ -1,4 +1,4 @@
-name: Build binaries Linux, Macos
+name: Build binaries for Linux
 
 on: [push, pull_request]
 
@@ -10,19 +10,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - { icon: '🟦', os: macOS-latest ,sys: macos, arch: x86_64 } 
           - { icon: '⬛', os: ubuntu-latest,sys: linux, arch: x86_64 }
-        #os: [ ubuntu-latest,  macOS-latest]
-        #os: [ubuntu-20.04, ubuntu-latest,  macOS-11, macOS-latest]
 
     steps:
-      - name: Provide fftw  (macOS)
-        if: runner.os == 'macOS'
-        run: |
-          # fftw3 
-          brew install fftw
-          fftw-wisdom -V
-            
       - uses: actions/checkout@v3
 
       - name: Build binaries

--- a/.github/workflows/linuxbuilds.yml
+++ b/.github/workflows/linuxbuilds.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Build binaries
         run: |
              cmake -S . -B build 
-             cmake --build build
+             cmake --build build --parallel 
              mkdir ./dist
              uname -a
              echo ${{runner.name}}

--- a/.github/workflows/macbuilds.yml
+++ b/.github/workflows/macbuilds.yml
@@ -1,0 +1,58 @@
+name: Build binaries for MacOS
+
+on: [push, pull_request]
+
+jobs:
+  build_wheels:
+    name: Build binary for ${{matrix.sys}}.${{matrix.arch}}
+    runs-on: ${{ matrix.os }}
+    continue-on-error: true
+    strategy:
+      matrix:
+        include:
+          - { icon: '🟦', os: macos-latest ,sys: macos, arch: x86_64 } 
+          - { icon: '🟦', os: macos-latest ,sys: macos, arch: arm64 } 
+          - { icon: '🟦', os: macos-13 ,sys: macos, arch: x86_64 } 
+          - { icon: '🟦', os: macos-13 ,sys: macos, arch: arm64 } 
+        #os: [ ubuntu-latest,  macOS-latest]
+        #os: [ubuntu-20.04, ubuntu-latest,  macOS-11, macOS-latest]
+
+    steps:
+      - name: Provide gfortran (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          # https://github.com/actions/virtual-environments/issues/2524
+          # https://github.com/cbg-ethz/dce/blob/master/.github/workflows/pkgdown.yaml
+          which gcc-13
+          which gfortran-13
+          sudo ln -s /usr/local/bin/gfortran-12 /usr/local/bin/gfortran
+          sudo ln -s /usr/local/bin/gcc-12 /usr/local/bin/gcc
+          sudo mkdir /usr/local/gfortran
+          sudo ln -s /usr/local/Cellar/gcc@12/*/lib/gcc/12 /usr/local/gfortran/lib
+          # gfortran --version
+          # gcc --version
+          # which gcc
+          # which gfortran
+
+      - name: Provide fftw  (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          # fftw3 
+          brew install fftw
+          fftw-wisdom -V
+            
+      - uses: actions/checkout@v3
+
+      - name: Build binaries
+        run: |
+             FC=gfortran-13 cmake -S . -B build 
+             cmake --build build
+             mkdir ./dist
+             uname -a
+             echo ${{runner.name}}
+             cp ./bin/sd.* ./dist/uppasd.${{matrix.sys}}.${{matrix.arch}}
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: uppasd.${{matrix.sys}}.${{matrix.arch}}
+          path: ./dist/

--- a/.github/workflows/macbuilds.yml
+++ b/.github/workflows/macbuilds.yml
@@ -18,22 +18,6 @@ jobs:
         #os: [ubuntu-20.04, ubuntu-latest,  macOS-11, macOS-latest]
 
     steps:
-      - name: Provide gfortran (macOS)
-        if: runner.os == 'macOS'
-        run: |
-          # https://github.com/actions/virtual-environments/issues/2524
-          # https://github.com/cbg-ethz/dce/blob/master/.github/workflows/pkgdown.yaml
-          which gcc-13
-          which gfortran-13
-          # sudo ln -s /usr/local/bin/gfortran-12 /usr/local/bin/gfortran
-          # sudo ln -s /usr/local/bin/gcc-12 /usr/local/bin/gcc
-          # sudo mkdir /usr/local/gfortran
-          # sudo ln -s /usr/local/Cellar/gcc@12/*/lib/gcc/12 /usr/local/gfortran/lib
-          # gfortran --version
-          # gcc --version
-          # which gcc
-          # which gfortran
-
       - name: Provide fftw  (macOS)
         if: runner.os == 'macOS'
         run: |

--- a/.github/workflows/macbuilds.yml
+++ b/.github/workflows/macbuilds.yml
@@ -25,10 +25,10 @@ jobs:
           # https://github.com/cbg-ethz/dce/blob/master/.github/workflows/pkgdown.yaml
           which gcc-13
           which gfortran-13
-          sudo ln -s /usr/local/bin/gfortran-12 /usr/local/bin/gfortran
-          sudo ln -s /usr/local/bin/gcc-12 /usr/local/bin/gcc
-          sudo mkdir /usr/local/gfortran
-          sudo ln -s /usr/local/Cellar/gcc@12/*/lib/gcc/12 /usr/local/gfortran/lib
+          # sudo ln -s /usr/local/bin/gfortran-12 /usr/local/bin/gfortran
+          # sudo ln -s /usr/local/bin/gcc-12 /usr/local/bin/gcc
+          # sudo mkdir /usr/local/gfortran
+          # sudo ln -s /usr/local/Cellar/gcc@12/*/lib/gcc/12 /usr/local/gfortran/lib
           # gfortran --version
           # gcc --version
           # which gcc
@@ -46,7 +46,7 @@ jobs:
       - name: Build binaries
         run: |
              FC=gfortran-13 cmake -S . -B build 
-             cmake --build build
+             cmake --build build --parallel
              mkdir ./dist
              uname -a
              echo ${{runner.name}}


### PR DESCRIPTION
Updating the github actions for compiling on MacOS.
It seems as the old action stopped working due to updates on the github-hosted runners but that has now been adressed in this PR.