### PR TITLE
Introducing ll_scale for force constant scaling

### DIFF
--- a/source/Lattice/latticehamiltonianinit.f90
+++ b/source/Lattice/latticehamiltonianinit.f90
@@ -43,7 +43,7 @@ contains
       do_ll_phonopy, Natom_phonopy, atomindex_phonopy, ll_inptens_phonopy )
 
       use NeighbourMap, only : setup_nm, setup_nm_nelem
-      use LatticeInputData, only : allocate_latthamiltonianinput
+      use LatticeInputData, only : allocate_latthamiltonianinput, ll_scale
       use LatticeHamiltonianData, only : allocate_llhamiltoniandata, allocate_lllhamiltoniandata, &
          allocate_llllhamiltoniandata, allocate_mlhamiltoniandata, allocate_mmlhamiltoniandata, allocate_mmllhamiltoniandata, &
          mml_tens_diag, lmm_tens_diag
@@ -227,6 +227,9 @@ contains
             0, 0)
          write(*,'(a)') ' done'
 
+         ! Rescale LL couplings if needed
+         if(ll_scale.ne.1.0_dblprec) ll_tens = ll_scale * ll_tens
+
          ! Print LL interactions
          if(do_prnstruct==1.or.do_prnstruct==4) then
             write(*,'(2x,a)',advance='no') "Print LL coordination shells"
@@ -271,6 +274,9 @@ contains
                ll_tens(1:3,1:3,j,i) = ll_inptens_phonopy(1:3,1:3,ja,ia) * fc_unitconv_phonopy
             end do
          end do
+
+         ! Rescale LL couplings if needed
+         if(ll_scale.ne.1.0_dblprec) ll_tens = ll_scale * ll_tens
 
          ! Print LL phonopy interactions
          if(do_prnstruct==1.or.do_prnstruct==4) then

--- a/source/Lattice/latticeinputdata.f90
+++ b/source/Lattice/latticeinputdata.f90
@@ -49,6 +49,7 @@ module LatticeInputData
    integer, dimension(:), allocatable :: ll_nn          !< No. shells of neighbours for LL
    integer :: nn_ll_tot                                 !< Calculated number of neighbours with PD interactions
    integer :: max_no_llshells                           !< Actual maximum number of shells for LL interactions
+   real(dblprec) :: ll_scale                            !< Manual scaling of LL couplings
 
 
    !LL phonopy data
@@ -164,6 +165,7 @@ contains
       !LL data
       llfile = 'llfile'
       do_ll  = 0
+      ll_scale=1.0_dblprec
 
       !LL phonopy data
       do_ll_phonopy = 0

--- a/source/Lattice/latticeinputhandler.f90
+++ b/source/Lattice/latticeinputhandler.f90
@@ -153,8 +153,8 @@ contains
                call ErrorHandling_check_file_exists(mmlfile, &
                   'Please specify mml <mmlfile> where <mmlfile> is a valid MML interaction file')
 
-            case('mml_scale')
-               read(ifile,*,iostat=i_err) mml_scale
+            case('ll_scale')
+               read(ifile,*,iostat=i_err) ll_scale
                if(i_err/=0) write(*,*) 'ERROR: Reading ',trim(keyword),' data',i_err
 
             case('mmll')


### PR DESCRIPTION
Following the same functionality available for many magnetic interactions, this PR introduces a scaling factor for lattice-lattice couplings.
Usage:
`ll_scale x.xx` 
which scales the force constant tensor.