### PR TITLE
Added additional algorithms for randomizing Jij and DMI.

### DIFF
--- a/source/Hamiltonian/hamiltonianinit.f90
+++ b/source/Hamiltonian/hamiltonianinit.f90
@@ -260,6 +260,7 @@ contains
 
                      !Re-scale DMI if needed
                      if(ham_inp%dm_scale.ne.1.0_dblprec) ham%dm_vect=ham_inp%dm_scale*ham%dm_vect
+
                   write(*,'(a)') ' done'
                   call deallocate_nm()
                endif
@@ -361,7 +362,7 @@ contains
             ! Randomize Jij if Edwards-Anderson model is enabled
             if(ham_inp%ea_model) then
                call randomize_exchange(NA,1,Natom,ham%max_no_neigh,ham%nlistsize, &
-                  ham%nlist,ham%ncoup,ham%aham,do_reduced,ham_inp%ea_sigma)
+                  ham%nlist,ham%ncoup,ham%aham,do_reduced,ham_inp%ea_sigma,ham_inp%ea_algo)
             end if
 
             if(do_prnstruct==1.or.do_prnstruct==4) then
@@ -508,6 +509,13 @@ contains
 
          !Re-scale DMI if needed
          if(ham_inp%dm_scale.ne.1.0_dblprec) ham%dm_vect=ham_inp%dm_scale*ham%dm_vect
+
+
+         ! Randomize Dij if random DM-model is enabled
+         if(ham_inp%rdm_model) then
+            call randomize_exchange(NA,3,Natom,ham%max_no_dmneigh,ham%dmlistsize, &
+               ham%dmlist,ham%dm_vect,ham%aham,do_reduced,ham_inp%rdm_sigma,ham_inp%rdm_algo)
+         end if
 
          ! Deallocate the large neighbour map.
          call deallocate_nm()
@@ -1591,8 +1599,9 @@ contains
    !> @details Loops over all couplings and multiplies the original value
    !> with a Gaussian random number between (-1,1)
    !----------------------------------------------------------------------------
-   subroutine randomize_exchange(NA,mdim,Natom,max_no_neigh,nlistsize,nlist,ncoup,aham,do_reduced,sigma)
+   subroutine randomize_exchange(NA,mdim,Natom,max_no_neigh,nlistsize,nlist,ncoup,aham,do_reduced,sigma, algorithm)
       
+      use Constants
       use RandomNumbers, only : rng_gaussian
 
       implicit none
@@ -1606,12 +1615,16 @@ contains
       real(dblprec), dimension(mdim,max_no_neigh, Natom), intent(inout) :: ncoup !< Heisenberg exchange couplings
       integer, dimension(Natom), optional, intent(in) :: aham !< Hamiltonian look-up table
       character(len=1), intent(in) :: do_reduced       !< Use reduced formulation of Hamiltonian (T/F)
-      real(dblprec),intent(in) :: sigma                  !< Standard deviaton for Gaussian RNG
+      real(dblprec),intent(in) :: sigma                !< Standard deviaton for Gaussian RNG
+      character(len=1), intent(in) :: algorithm        !< Choice of randomization algoritm
 
       !.. Local variables
       integer :: iatom,jatom,ineigh,iham,ielem, jneigh, jham, jelem
       real(dblprec), dimension(:,:,:), allocatable :: rng_arr
+      real(dblprec) :: xc_sign, xc_norm
+      real(dblprec) :: fc2
 
+      fc2 = 2.0_dblprec * mry/mub
       ! loop over neighbor list 
       !!! if(do_reduced=='Y') then
       !!!    allocate(rng_arr(mdim,max_no_neigh,NA))
@@ -1628,25 +1641,97 @@ contains
       allocate(rng_arr(mdim,max_no_neigh,Natom))
       call rng_gaussian(rng_arr,mdim*max_no_neigh*Natom,sigma)
 
-      do iatom=1,Natom
-         iham=aham(iatom)
-         do ineigh=1,nlistsize(iham)
-            jatom=nlist(ineigh,iatom)
-            do ielem=1,mdim
-               ncoup(ielem,ineigh,iham)=ncoup(ielem,ineigh,iham)*rng_arr(ielem,ineigh,iham)
+
+      ! Set the sign for symmetry check: Jij = Jji but Dij = -Dji
+      xc_sign = 1.0_dblprec
+      if(mdim==3) then  !Assume DMI if mdim=3
+         xc_sign = -1.0_dblprec
+      end if
+
+      ! Default algorithm (S)cale: Scale the existing coupling by multiplying with random Gaussian number
+      if (algorithm == 'S') then
+         do iatom=1,Natom
+            iham=aham(iatom)
+            do ineigh=1,nlistsize(iham)
+               jatom=nlist(ineigh,iatom)
+               do ielem=1,mdim
+                  ncoup(ielem,ineigh,iham)=ncoup(ielem,ineigh,iham)*rng_arr(ielem,ineigh,iham)
+               enddo
+               ! Ensure symmetry Jij=Jji
+               jham=aham(jatom)
+               do jneigh=1,nlistsize(jham)
+                  if (nlist(jneigh,jatom)==iatom) then
+                     do jelem=1,mdim
+                        ncoup(jelem,jneigh,jham)=xc_sign*ncoup(jelem,ineigh,iham)
+                     enddo
+                  end if
+               end do
             enddo
-            ! Ensure symmetry Jij=Jji
-            jham=aham(jatom)
-            do jneigh=1,nlistsize(jham)
-               if (nlist(jneigh,jatom)==iatom) then
-                  do jelem=1,mdim
-                     ncoup(jelem,jneigh,jham)=ncoup(jelem,ineigh,iham)
-                  enddo
-               end if
-            end do
-         enddo
-      end do
-      !!! end if
+         end do
+      ! Alternative algorithm (A)round: Add a random Gaussian number to the existing value
+      else if (algorithm == 'A') then
+         do iatom=1,Natom
+            iham=aham(iatom)
+            do ineigh=1,nlistsize(iham)
+               jatom=nlist(ineigh,iatom)
+               do ielem=1,mdim
+                  ncoup(ielem,ineigh,iham)=ncoup(ielem,ineigh,iham)+rng_arr(ielem,ineigh,iham)
+               enddo
+               ! Ensure symmetry Jij=Jji
+               jham=aham(jatom)
+               do jneigh=1,nlistsize(jham)
+                  if (nlist(jneigh,jatom)==iatom) then
+                     do jelem=1,mdim
+                        ncoup(jelem,jneigh,jham)=xc_sign*ncoup(jelem,ineigh,iham)
+                     enddo
+                  end if
+               end do
+            enddo
+         end do
+      ! Alternative algorithm (F)ully random: Set each individual coupling component to a random 
+      ! Gaussian number (then sigma sets the magnitude of each component)
+      else if (algorithm == 'F') then
+         do iatom=1,Natom
+            iham=aham(iatom)
+            do ineigh=1,nlistsize(iham)
+               jatom=nlist(ineigh,iatom)
+               do ielem=1,mdim
+                  ncoup(ielem,ineigh,iham)=rng_arr(ielem,ineigh,iham)*fc2
+               enddo
+               ! Ensure symmetry Jij=Jji
+               jham=aham(jatom)
+               do jneigh=1,nlistsize(jham)
+                  if (nlist(jneigh,jatom)==iatom) then
+                     do jelem=1,mdim
+                        ncoup(jelem,jneigh,jham)=xc_sign*ncoup(jelem,ineigh,iham)
+                     enddo
+                  end if
+               end do
+            enddo
+         end do
+      ! Alternative algorithm (R)otate and scale: Set each component by multiplying the initial magnitude with a 
+      ! Gaussian random number in each direction
+      else if (algorithm == 'R') then
+         do iatom=1,Natom
+            iham=aham(iatom)
+            do ineigh=1,nlistsize(iham)
+               jatom=nlist(ineigh,iatom)
+               xc_norm = sqrt(sum(ncoup(:,ineigh,iham)*ncoup(:,ineigh,iham)))
+               do ielem=1,mdim
+                  ncoup(ielem,ineigh,iham)=xc_norm*rng_arr(ielem,ineigh,iham)
+               enddo
+               ! Ensure symmetry Jij=Jji
+               jham=aham(jatom)
+               do jneigh=1,nlistsize(jham)
+                  if (nlist(jneigh,jatom)==iatom) then
+                     do jelem=1,mdim
+                        ncoup(jelem,jneigh,jham)=xc_sign*ncoup(jelem,ineigh,iham)
+                     enddo
+                  end if
+               end do
+            enddo
+         end do
+      end if
       !
       deallocate(rng_arr)
       !

--- a/source/Input/inputdata.f90
+++ b/source/Input/inputdata.f90
@@ -337,6 +337,7 @@ contains
       ham_inp%jij_scale         = 1.0_dblprec
       ham_inp%ea_model          = .false.
       ham_inp%ea_sigma          = 1.0_dblprec
+      ham_inp%ea_algo           = 'S'
 
       !Anisotropy data
       ham_inp%kfile             = 'kfile'
@@ -347,6 +348,9 @@ contains
       ham_inp%dmfile            = 'dmfile'
       ham_inp%do_dm             = 0
       ham_inp%dm_scale          = 1.0_dblprec
+      ham_inp%rdm_model         = .false.
+      ham_inp%rdm_sigma         = 1.0_dblprec
+      ham_inp%rdm_algo          = 'S'
 
       !Symmetric anisotropic data
       ham_inp%safile            = 'safile'

--- a/source/Input/inputdatatype.f90
+++ b/source/Input/inputdatatype.f90
@@ -33,6 +33,7 @@ module InputDataType
       real(dblprec) :: jij_scale                               !< Rescale Jij couplings manually
       logical ::  ea_model                                     !< Randomize exchange couplings for Edwards-Anderson model T,(F)
       real(dblprec) ::  ea_sigma                               !< Standard deviation for Edwards-Anderson randomization
+      character(len=1) :: ea_algo                              !< Algoritm for Edwards-Anderson randomization
       !---------------------------------------------------------------------------------
       ! Anisotropy data
       !---------------------------------------------------------------------------------
@@ -52,6 +53,9 @@ module InputDataType
       integer :: max_no_dmshells                            !< Actual maximum number of shells for DM interactions
       character(len=35) :: dmfile                           !< File name for Dzyaloshinskii-Moriya data
       real(dblprec) :: dm_scale                             !< Rescale Dij couplings manually
+      logical ::  rdm_model                                 !< Randomize Dij couplings
+      real(dblprec) ::  rdm_sigma                           !< Standard deviation for random Dij couplings
+      character(len=1) :: rdm_algo                          !< Algoritm for random Dij couplings
       integer, dimension(:), allocatable :: dm_nn           !< No. shells of neighbours for DM
       real(dblprec), dimension(:,:,:), allocatable :: dm_redcoord    !< Neighbour vectors for DM
       real(dblprec), dimension(:,:,:,:,:), allocatable :: dm_inpvect !< Neighbour vectors for DM

--- a/source/Input/inputhandler.f90
+++ b/source/Input/inputhandler.f90
@@ -376,6 +376,10 @@ contains
                read(ifile,*,iostat=i_err) ham_inp%ea_sigma
                if(i_err/=0) write(*,*) 'ERROR: Reading ',trim(keyword),' data',i_err
 
+            case('ea_algo')
+               read(ifile,*,iostat=i_err) ham_inp%ea_algo
+               if(i_err/=0) write(*,*) 'ERROR: Reading ',trim(keyword),' data',i_err
+
             case('exc_inter')
                read(ifile,*,iostat=i_err) ham_inp%exc_inter
                if(i_err/=0) write(*,*) 'ERROR: Reading ',trim(keyword),' data',i_err
@@ -453,6 +457,18 @@ contains
 
             case('dm_scale')
                read(ifile,*,iostat=i_err) ham_inp%dm_scale
+               if(i_err/=0) write(*,*) 'ERROR: Reading ',trim(keyword),' data',i_err
+
+            case('rdm_model')
+               read(ifile,*,iostat=i_err) ham_inp%rdm_model
+               if(i_err/=0) write(*,*) 'ERROR: Reading ',trim(keyword),' data',i_err
+
+            case('rdm_sigma')
+               read(ifile,*,iostat=i_err) ham_inp%rdm_sigma
+               if(i_err/=0) write(*,*) 'ERROR: Reading ',trim(keyword),' data',i_err
+
+            case('rdm_algo')
+               read(ifile,*,iostat=i_err) ham_inp%rdm_algo
                if(i_err/=0) write(*,*) 'ERROR: Reading ',trim(keyword),' data',i_err
 
             case('sa')


### PR DESCRIPTION
Extensions to the existing functionality to randomize exchange interactions, e.g. to simulate Edwards-Anderson models.

The most important update is that now Dzyaloshinskii-Moriya interactions can be randomized with `rdm_model T`

The extended functionality includes:
i)     Scaling of existing exchange by multiplying with random (Gaussian) number
ii)    Adding random (Gaussian) number to the existing exchange coupling
iii)   Overwrite existing exchange with random (Gaussian) number
iv)   Rotate and scale vectorial exchange with random (Gaussian) numbers

