### PR TITLE
Replace external definitions with use omp_lib

### DIFF
--- a/source/MonteCarlo/montecarlo.f90
+++ b/source/MonteCarlo/montecarlo.f90
@@ -134,7 +134,6 @@ contains
       real(dblprec),dimension(natom,mensemble) :: flipprob_a ,newmmom_a,mflip
       real(dblprec),dimension(3,natom,mensemble) :: newmom_a,flipprob_g,flipprob_m
 
-      integer, external :: omp_get_thread_num
       real(dblprec) :: henergy
       real(dblprec), dimension(3) :: loc_demag_fld, loc_mag_fld
 

--- a/source/Tools/profiling.f90
+++ b/source/Tools/profiling.f90
@@ -4,6 +4,7 @@
 !> @copyright
 !> GNU Public License.
 module Profiling
+   use omp_lib
    use Parameters
 
    implicit none
@@ -157,7 +158,6 @@ contains
       logical :: parallel,init
       integer, parameter :: ncat=14 ! define timing categories
       integer :: i,ii,nprocs
-      integer, external :: omp_get_num_threads,OMP_GET_NUM_PROCS
 
       !cputime routine gives a real
       real(kind=8) :: total,total0,time,time0


### PR DESCRIPTION
Using external leads to a name mangling issue where the linker is looking for omp_get_thread_num_, which is not defined in llvm-openmp.


This is the last issue I ran into while trying to compile UppASD on Windows using flang 19.